### PR TITLE
feat(dependencies): increase release age for node GC-4350

### DIFF
--- a/dependencies/node.json5
+++ b/dependencies/node.json5
@@ -6,7 +6,7 @@
       description: "stability: node",
       matchDepNames: ["node"],
       matchUpdateTypes: ["major", "minor", "patch"],
-      minimumReleaseAge: "7 days",
+      minimumReleaseAge: "14 days",
     },
   ],
 }


### PR DESCRIPTION
nvm manager uses node-version datasource which has the new version on day 0.
-> renovate creates pr after 7 days, and merges it.
dockerfile uses docker datasource, which publishes the new images after 10 days.
-> renovate creates pr after 10 days with same name and cannot merge it because a pr with the same name was merged previously.

extending the release age for node to 14 days should fix it, the node group as part of "group:recommended" should group it properly.